### PR TITLE
Modal closes on iphone

### DIFF
--- a/app/assets/javascripts/static_pages.js
+++ b/app/assets/javascripts/static_pages.js
@@ -9,13 +9,9 @@ $(document).ready(function() {
     modalImg.attr("src", this.src);
   });
 
-  window.onclick = function(event) {
-    var sameModal = document.getElementById("myModal");
-
-    if (event.target === sameModal) {
-      modal.fadeOut();
-    }
-  }
+  modal.click(function(event) {
+    modal.fadeOut();
+  })
 
   $(window).resize(function() {
     if(window.innerWidth > 991) {

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -28,7 +28,7 @@
 }
 
 .modal {
-  margin-top: 5rem;
+  padding-top: 5rem;
 }
 
 /* Caption of Modal Image (Image Text) - Same Width as the Image */


### PR DESCRIPTION
Made two changes! I modified the JS so that when you click on the modal, it closes. And I changed the CSS so that the modal technically takes over the entire screen (changed margin to padding). The modal doesn't actually look any different, it just registers the space all around the modal as part of the modal, so that if you click anywhere on the screen at all, the modal registers the click event.

I checked that it worked on my iphone and it does!